### PR TITLE
Fix sync conditions and logger output

### DIFF
--- a/src/homelab_assistant/helpers/portainer.py
+++ b/src/homelab_assistant/helpers/portainer.py
@@ -45,11 +45,17 @@ class PortainerHelper:
         response = self.session.get(f"{self.portainer_url}/api/stacks")
         response.raise_for_status()
 
-        endpoint_grouped_stack_info = {self.endpoint_mapping[endpoint]: {} for endpoint in
-                                       {stack["EndpointId"] for stack in response.json()}}
+        endpoint_grouped_stack_info = {
+            self.endpoint_mapping[endpoint]: {} for endpoint in
+            {stack["EndpointId"] for stack in response.json()}
+            if endpoint in self.endpoint_mapping
+        }
 
         for stack in response.json():
-            friendly_endpoint_name = self.endpoint_mapping[stack["EndpointId"]]
+            if (endpoint := stack["EndpointId"] not in self.endpoint_mapping):
+                continue
+
+            friendly_endpoint_name = self.endpoint_mapping[endpoint]
             endpoint_grouped_stack_info[friendly_endpoint_name][stack["Name"]] = stack
 
         return endpoint_grouped_stack_info

--- a/src/homelab_assistant/runners/sync.py
+++ b/src/homelab_assistant/runners/sync.py
@@ -121,6 +121,10 @@ def sync_endpoint(config: Config, portainer_helper: PortainerHelper, endpoint_na
         if portainer_compose != compose:
             display_compose_diff(base_compose=portainer_compose, new_compose=compose)
 
+        # If not syncing, exit early.
+        if not push:
+            continue
+
         # Add required environment variables and compose file to the update payload, and update the stack.
         try:
             portainer_helper.update_stack(
@@ -154,11 +158,11 @@ def display_compose_diff(base_compose: str, new_compose: str) -> None:
         return
 
     logger.info("Compose diff:")
-    for line in lines:
+    for line in lines[2:]:
         colour = "default"
         if line.startswith("+"):
             colour = "green"
         elif line.startswith("-"):
             colour = "red"
 
-        logger.info(f"[{colour}]{line}[/]")
+        logger.info(f"[{colour}]{line}[/]", extra={"highlighter": None})


### PR DESCRIPTION
- Sync runs without `--push` now won't push incorrectly
- Logger diff output disables Rich's inbuilt highlighting
- Discard stack information for endpoints no longer available